### PR TITLE
Bug/crash in high concurrency due to object moves

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -4,3 +4,7 @@ shards:
     git: https://github.com/ysbaddaden/minitest.cr.git
     version: 1.0.1
 
+  mt_helpers:
+    git: https://github.com/pbrumm/mt_helpers.git
+    version: 0.1.0+git.commit.d66f04da7a0e03e4c305e63d1a84e23e9bead83f
+

--- a/shard.yml
+++ b/shard.yml
@@ -11,4 +11,7 @@ development_dependencies:
   minitest:
     github: ysbaddaden/minitest.cr
 
+dependencies:
+  mt_helpers:
+    github: pbrumm/mt_helpers
 license: Apache-2.0

--- a/src/connection.cr
+++ b/src/connection.cr
@@ -1,5 +1,5 @@
 require "./pool"
-require "mt_helper"
+require "mt_helpers"
 
 # Sharing connections across coroutines.
 #
@@ -9,6 +9,7 @@ require "mt_helper"
 class ConnectionPool(T) < Pool(T)
   # TODO: reap connection of dead coroutines that didn't checkin (or died before)
   # FIXME: thread safety
+  @connections = SafeHash(UInt64, T).new
 
   # Returns true if a connection was checkout for the current coroutine.
   def active?
@@ -41,6 +42,6 @@ class ConnectionPool(T) < Pool(T)
   end
 
   private def connections
-    @connections ||= SafeHash of UInt64 => T
+    @connections
   end
 end

--- a/src/connection.cr
+++ b/src/connection.cr
@@ -1,4 +1,5 @@
 require "./pool"
+require "mt_helper"
 
 # Sharing connections across coroutines.
 #
@@ -40,6 +41,6 @@ class ConnectionPool(T) < Pool(T)
   end
 
   private def connections
-    @connections ||= {} of UInt64 => T
+    @connections ||= SafeHash of UInt64 => T
   end
 end

--- a/src/pool.cr
+++ b/src/pool.cr
@@ -1,3 +1,5 @@
+require "mt_helper"
+
 # Generic pool.
 #
 # It will create N instances that can be checkin then checkout. Trying to
@@ -32,7 +34,7 @@ class Pool(T)
     @buffer = Slice(UInt8).new(1)
     @size = 0
     @pending = @capacity
-    @pool = [] of T
+    @pool = SafeArray of T
     @block = block
   end
 

--- a/src/pool.cr
+++ b/src/pool.cr
@@ -1,4 +1,4 @@
-require "mt_helper"
+require "mt_helpers"
 
 # Generic pool.
 #
@@ -34,7 +34,7 @@ class Pool(T)
     @buffer = Slice(UInt8).new(1)
     @size = 0
     @pending = @capacity
-    @pool = SafeArray of T
+    @pool = SafeArray(T).new
     @block = block
   end
 


### PR DESCRIPTION
you should use the https://github.com/NeuraLegion/mt_helpers repo instead of mine below in the shards.

also I submitted the following pull as this is where I found it.
https://github.com/stefanwille/crystal-redis/pull/132

with -Dpreview_mt you can't trust the Hash, Array, Set commands outside of a mutex.   

using the mt_helpers makes it easy but adds a dependency.    
the errors I was getting were crashes, array index out of bounds in the pool code and run away redis connections.   

these changes resolve the issue.